### PR TITLE
Fix mailto links breaking attachment flow

### DIFF
--- a/src/main/java/io/orangebeard/listener/helper/OrangebeardLogger.java
+++ b/src/main/java/io/orangebeard/listener/helper/OrangebeardLogger.java
@@ -27,11 +27,12 @@ public class OrangebeardLogger {
     public void attachFilesIfPresent(UUID testId, UUID testRunId, String message) {
         Matcher attachments = attachmentPattern.matcher(message);
         while (attachments.find()) {
-            if (!attachments.group(1).startsWith("http://") && !attachments.group(1).startsWith("https://")) {
-                File attachmentFile = new File(rootPath, attachments.group(1));
-                String fileName = attachmentFile.getName();
-
+            if (!attachments.group(1).startsWith("http://") &&
+                    !attachments.group(1).startsWith("https://") &&
+                    !attachments.group(1).startsWith("mailto:")) {
                 try {
+                    File attachmentFile = new File(rootPath, attachments.group(1));
+                    String fileName = attachmentFile.getName();
                     Attachment attachment = Attachment.builder()
                             .file(new Attachment.File(attachmentFile))
                             .message(fileName)
@@ -43,7 +44,7 @@ public class OrangebeardLogger {
 
                     orangebeardClient.sendAttachment(attachment);
                 } catch (IOException e) {
-                    logger.warn("Unable to read attachment file: " + fileName);
+                    logger.warn("Unable to read attachment file for: " + attachments.group(1));
                 }
             }
         }

--- a/src/test/java/io/orangebeard/listener/OrangebeardLoggerTest.java
+++ b/src/test/java/io/orangebeard/listener/OrangebeardLoggerTest.java
@@ -1,25 +1,18 @@
 package io.orangebeard.listener;
 
-import io.orangebeard.client.OrangebeardClient;
-
 import io.orangebeard.client.OrangebeardV2Client;
 import io.orangebeard.client.entity.Attachment;
 import io.orangebeard.listener.helper.OrangebeardLogger;
 
 import org.junit.Test;
-import org.mockito.Mock;
-
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class OrangebeardLoggerTest {
-
 
     private final OrangebeardV2Client orangebeardV2Client = mock(OrangebeardV2Client.class);
     private final OrangebeardLogger orangebeardLogger = new OrangebeardLogger(orangebeardV2Client, "ROOTPATH");
@@ -37,6 +30,6 @@ public class OrangebeardLoggerTest {
     @Test
     public void mailto_links_are_not_attachments() {
         orangebeardLogger.attachFilesIfPresent(UUID.randomUUID(), UUID.randomUUID(), MESSAGE_WITH_MAILTO_LINKS);
-        verify(orangebeardV2Client,never()).sendAttachment(any(Attachment.class));
+        verify(orangebeardV2Client, never()).sendAttachment(any(Attachment.class));
     }
 }

--- a/src/test/java/io/orangebeard/listener/OrangebeardLoggerTest.java
+++ b/src/test/java/io/orangebeard/listener/OrangebeardLoggerTest.java
@@ -1,0 +1,42 @@
+package io.orangebeard.listener;
+
+import io.orangebeard.client.OrangebeardClient;
+
+import io.orangebeard.client.OrangebeardV2Client;
+import io.orangebeard.client.entity.Attachment;
+import io.orangebeard.listener.helper.OrangebeardLogger;
+
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class OrangebeardLoggerTest {
+
+
+    private final OrangebeardV2Client orangebeardV2Client = mock(OrangebeardV2Client.class);
+    private final OrangebeardLogger orangebeardLogger = new OrangebeardLogger(orangebeardV2Client, "ROOTPATH");
+    private static final String MESSAGE_WITH_MAILTO_LINKS = "<table class=\"toolchainTable scriptTable\">\n" +
+            "\t<tbody><tr class=\"slimRowTitle\">\n" +
+            "\t\t<td colspan=\"3\">script</td>\n" +
+            "\t</tr>\n" +
+            "\t<tr class=\"slimRowColor8\">\n" +
+            "\t\t<td><span class=\"page-variable\">$mailaddress</span>&lt;-[<a href=\"mailto:test@mail.net\">test@mail.net</a>]</td>\n" +
+            "\t\t<td>value of</td>\n" +
+            "\t\t<td><a href=\"mailto:test@mail.net\">test@mail.net</a></td>\n" +
+            "\t</tr>\n" +
+            "</tbody></table>";
+
+    @Test
+    public void mailto_links_are_not_attachments() {
+        orangebeardLogger.attachFilesIfPresent(UUID.randomUUID(), UUID.randomUUID(), MESSAGE_WITH_MAILTO_LINKS);
+        verify(orangebeardV2Client,never()).sendAttachment(any(Attachment.class));
+    }
+}


### PR DESCRIPTION
move file instance to try block to prevent test from getting interrupted, Exclude mailto:links from attachment processing