### PR TITLE
3926 set log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,14 @@ orangebeard.project=<PROJECT_NAME>
 orangebeard.testset=<TESTSET_NAME>
 
 # optional
+orangebeard.logLevel=INFO
 orangebeard.description=<DESCRIPTION>
 orangebeard.attributes=key:value; value;
 ```
 
 Be warned: the access token is a credential token. We advise you to store this token in a credential store, and pass it to the listener through environment properties. See below how to do that! 
+
+The log level is set to INFO by default. Valid values are: ```DEBUG```, ```INFO```, ```WARN``` and ```ERROR```. Logs of the set level and up to be logged. So if you were to set the log level to ```WARN```, only ```WARN``` and ```ERROR``` logs will be logged.  
 
 ### Environment properties
 Properties can also be set in the build, by passing them to the maven build. For example:

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <!--dependency versions-->
         <fitnesse.version>20211030</fitnesse.version>
         <hsac.version>5.0.0</hsac.version>
-        <java.client.version>1.2.2-SNAPSHOT</java.client.version>
+        <java.client.version>1.2.2</java.client.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <!--dependency versions-->
         <fitnesse.version>20211030</fitnesse.version>
         <hsac.version>5.0.0</hsac.version>
-        <java.client.version>1.2.2</java.client.version>
+        <java.client.version>1.2.3</java.client.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <!--dependency versions-->
         <fitnesse.version>20211030</fitnesse.version>
         <hsac.version>5.0.0</hsac.version>
-        <java.client.version>1.2.1</java.client.version>
+        <java.client.version>1.2.2-SNAPSHOT</java.client.version>
     </properties>
 
     <dependencies>

--- a/src/test/java/io/orangebeard/listener/OrangebeardTestSystemListenerTest.java
+++ b/src/test/java/io/orangebeard/listener/OrangebeardTestSystemListenerTest.java
@@ -134,9 +134,9 @@ public class OrangebeardTestSystemListenerTest {
 
     @Test
     public void when_a_table_is_logged_and_it_is_an_warn_loglevel_it_is_not_sent_to_orangebeard_when_this_should_not_be_the_case() {
-        when(orangebeardProperties.logShouldBeDispatchedToOrangebeard(LogLevel.warn)).thenReturn(false);
+        when(orangebeardProperties.logShouldBeDispatchedToOrangebeard(LogLevel.error)).thenReturn(false);
 
-        orangebeardTestSystemListener.testOutputChunk(testPage, "<table class=\"warn\"></table>");
+        orangebeardTestSystemListener.testOutputChunk(testPage, "<table class=\"error\"></table>");
 
         verify(orangebeardClient, times(0)).log(any(Log.class));
     }

--- a/src/test/java/io/orangebeard/listener/OrangebeardTestSystemListenerTest.java
+++ b/src/test/java/io/orangebeard/listener/OrangebeardTestSystemListenerTest.java
@@ -134,6 +134,8 @@ public class OrangebeardTestSystemListenerTest {
 
     @Test
     public void when_a_table_is_logged_and_it_is_an_warn_loglevel_it_is_not_sent_to_orangebeard_when_this_should_not_be_the_case() {
+        when(orangebeardProperties.logShouldBeDispatchedToOrangebeard(LogLevel.warn)).thenReturn(false);
+
         orangebeardTestSystemListener.testOutputChunk(testPage, "<table class=\"warn\"></table>");
 
         verify(orangebeardClient, times(0)).log(any(Log.class));

--- a/src/test/java/io/orangebeard/listener/OrangebeardTestSystemListenerTest.java
+++ b/src/test/java/io/orangebeard/listener/OrangebeardTestSystemListenerTest.java
@@ -100,7 +100,7 @@ public class OrangebeardTestSystemListenerTest {
 
         orangebeardTestSystemListener.testOutputChunk(testPage, "");
 
-        verify(orangebeardClient, times(1)).log(any());
+        verify(orangebeardClient, times(1)).log(any(Log.class));
         verify(orangebeardLogger).attachFilesIfPresent(any(), any(), any());
     }
 
@@ -110,7 +110,7 @@ public class OrangebeardTestSystemListenerTest {
 
         orangebeardTestSystemListener.testOutputChunk(testPage, "");
 
-        verify(orangebeardClient, times(0)).log(any());
+        verify(orangebeardClient, times(0)).log(any(Log.class));
     }
 
     @Test
@@ -136,7 +136,7 @@ public class OrangebeardTestSystemListenerTest {
     public void when_a_table_is_logged_and_it_is_an_warn_loglevel_it_is_not_sent_to_orangebeard_when_this_should_not_be_the_case() {
         orangebeardTestSystemListener.testOutputChunk(testPage, "<table class=\"warn\"></table>");
 
-        verify(orangebeardClient, times(0)).log(any());
+        verify(orangebeardClient, times(0)).log(any(Log.class));
     }
 
     @Test
@@ -202,6 +202,6 @@ public class OrangebeardTestSystemListenerTest {
 
         orangebeardTestSystemListener.testStarted(testPage);
 
-        verify(orangebeardClient, times(0)).log(any());
+        verify(orangebeardClient, times(0)).log(any(Log.class));
     }
 }


### PR DESCRIPTION
Be able to set lowest log level with the ```orangebeard.logLevel``` property. 

Disabled the option to use the V1 listener api. V2 is now the only listener api used. 