### PR TITLE
Conform to new UI datamodel

### DIFF
--- a/src/main/java/io/orangebeard/listener/helper/TypeConverter.java
+++ b/src/main/java/io/orangebeard/listener/helper/TypeConverter.java
@@ -32,11 +32,11 @@ public class TypeConverter {
     public static TestItemType determinePageType(String pageName) {
         switch (pageName) {
             case "SuiteSetUp":
-                return TestItemType.BEFORE_METHOD;
+                return TestItemType.BEFORE_SUITE;
             case "SuiteTearDown":
-                return TestItemType.AFTER_METHOD;
+                return TestItemType.AFTER_SUITE;
             default:
-                return TestItemType.STEP;
+                return TestItemType.TEST;
         }
     }
 

--- a/src/test/java/io/orangebeard/listener/helper/TypeConverterTest.java
+++ b/src/test/java/io/orangebeard/listener/helper/TypeConverterTest.java
@@ -29,16 +29,16 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void suitesetup_is_a_before_method() {
+    public void suitesetup_is_a_before_suite() {
         TestItemType result = TypeConverter.determinePageType("SuiteSetUp");
 
-        assertThat(result).isEqualTo(TestItemType.BEFORE_METHOD);
+        assertThat(result).isEqualTo(TestItemType.BEFORE_SUITE);
     }
 
     @Test
-    public void suiteteardown_is_an_after_method() {
+    public void suiteteardown_is_an_after_suite() {
         TestItemType result = TypeConverter.determinePageType("SuiteTearDown");
 
-        assertThat(result).isEqualTo(TestItemType.AFTER_METHOD);
+        assertThat(result).isEqualTo(TestItemType.AFTER_SUITE);
     }
 }


### PR DESCRIPTION
No longer use step item type for tests at the cost of losing the setup/teardown toggle in the old UI, but at the benefit of allowing the right counts to be displayed  for in-progress runs in the new UI